### PR TITLE
Macro for markers & minor cleanups

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1,155 +1,51 @@
 /// Types able to be initialized with random data.
 pub trait Randomizable {}
 
-impl Randomizable for i8  {}
-impl Randomizable for i16 {}
-impl Randomizable for i32 {}
-impl Randomizable for i64 {}
-impl Randomizable for u8  {}
-impl Randomizable for u16 {}
-impl Randomizable for u32 {}
-impl Randomizable for u64 {}
-
-impl<T> Randomizable for [T]     where T: Randomizable {}
-impl<T> Randomizable for [T;  1] where T: Randomizable {}
-impl<T> Randomizable for [T;  2] where T: Randomizable {}
-impl<T> Randomizable for [T;  3] where T: Randomizable {}
-impl<T> Randomizable for [T;  4] where T: Randomizable {}
-impl<T> Randomizable for [T;  5] where T: Randomizable {}
-impl<T> Randomizable for [T;  6] where T: Randomizable {}
-impl<T> Randomizable for [T;  7] where T: Randomizable {}
-impl<T> Randomizable for [T;  8] where T: Randomizable {}
-impl<T> Randomizable for [T;  9] where T: Randomizable {}
-impl<T> Randomizable for [T; 10] where T: Randomizable {}
-impl<T> Randomizable for [T; 11] where T: Randomizable {}
-impl<T> Randomizable for [T; 12] where T: Randomizable {}
-impl<T> Randomizable for [T; 13] where T: Randomizable {}
-impl<T> Randomizable for [T; 14] where T: Randomizable {}
-impl<T> Randomizable for [T; 15] where T: Randomizable {}
-impl<T> Randomizable for [T; 16] where T: Randomizable {}
-impl<T> Randomizable for [T; 17] where T: Randomizable {}
-impl<T> Randomizable for [T; 18] where T: Randomizable {}
-impl<T> Randomizable for [T; 19] where T: Randomizable {}
-impl<T> Randomizable for [T; 20] where T: Randomizable {}
-impl<T> Randomizable for [T; 21] where T: Randomizable {}
-impl<T> Randomizable for [T; 22] where T: Randomizable {}
-impl<T> Randomizable for [T; 23] where T: Randomizable {}
-impl<T> Randomizable for [T; 24] where T: Randomizable {}
-impl<T> Randomizable for [T; 25] where T: Randomizable {}
-impl<T> Randomizable for [T; 26] where T: Randomizable {}
-impl<T> Randomizable for [T; 27] where T: Randomizable {}
-impl<T> Randomizable for [T; 28] where T: Randomizable {}
-impl<T> Randomizable for [T; 29] where T: Randomizable {}
-impl<T> Randomizable for [T; 30] where T: Randomizable {}
-impl<T> Randomizable for [T; 31] where T: Randomizable {}
-impl<T> Randomizable for [T; 32] where T: Randomizable {}
-impl<T> Randomizable for [T; 33] where T: Randomizable {}
-impl<T> Randomizable for [T; 34] where T: Randomizable {}
-impl<T> Randomizable for [T; 35] where T: Randomizable {}
-impl<T> Randomizable for [T; 36] where T: Randomizable {}
-impl<T> Randomizable for [T; 37] where T: Randomizable {}
-impl<T> Randomizable for [T; 38] where T: Randomizable {}
-impl<T> Randomizable for [T; 39] where T: Randomizable {}
-impl<T> Randomizable for [T; 40] where T: Randomizable {}
-impl<T> Randomizable for [T; 41] where T: Randomizable {}
-impl<T> Randomizable for [T; 42] where T: Randomizable {}
-impl<T> Randomizable for [T; 43] where T: Randomizable {}
-impl<T> Randomizable for [T; 44] where T: Randomizable {}
-impl<T> Randomizable for [T; 45] where T: Randomizable {}
-impl<T> Randomizable for [T; 46] where T: Randomizable {}
-impl<T> Randomizable for [T; 47] where T: Randomizable {}
-impl<T> Randomizable for [T; 48] where T: Randomizable {}
-impl<T> Randomizable for [T; 49] where T: Randomizable {}
-impl<T> Randomizable for [T; 50] where T: Randomizable {}
-impl<T> Randomizable for [T; 51] where T: Randomizable {}
-impl<T> Randomizable for [T; 52] where T: Randomizable {}
-impl<T> Randomizable for [T; 53] where T: Randomizable {}
-impl<T> Randomizable for [T; 54] where T: Randomizable {}
-impl<T> Randomizable for [T; 55] where T: Randomizable {}
-impl<T> Randomizable for [T; 56] where T: Randomizable {}
-impl<T> Randomizable for [T; 57] where T: Randomizable {}
-impl<T> Randomizable for [T; 58] where T: Randomizable {}
-impl<T> Randomizable for [T; 59] where T: Randomizable {}
-impl<T> Randomizable for [T; 60] where T: Randomizable {}
-impl<T> Randomizable for [T; 61] where T: Randomizable {}
-impl<T> Randomizable for [T; 62] where T: Randomizable {}
-impl<T> Randomizable for [T; 63] where T: Randomizable {}
-impl<T> Randomizable for [T; 64] where T: Randomizable {}
-
 /// Types able to be initialized with zeroed data.
 pub trait Zeroable {}
 
-impl Zeroable for i8  {}
-impl Zeroable for i16 {}
-impl Zeroable for i32 {}
-impl Zeroable for i64 {}
-impl Zeroable for u8  {}
-impl Zeroable for u16 {}
-impl Zeroable for u32 {}
-impl Zeroable for u64 {}
+impl<T: Randomizable> Randomizable for [T] {}
+impl<T: Zeroable> Zeroable for [T] {}
 
-impl<T> Zeroable for [T]     where T: Zeroable {}
-impl<T> Zeroable for [T;  1] where T: Zeroable {}
-impl<T> Zeroable for [T;  2] where T: Zeroable {}
-impl<T> Zeroable for [T;  3] where T: Zeroable {}
-impl<T> Zeroable for [T;  4] where T: Zeroable {}
-impl<T> Zeroable for [T;  5] where T: Zeroable {}
-impl<T> Zeroable for [T;  6] where T: Zeroable {}
-impl<T> Zeroable for [T;  7] where T: Zeroable {}
-impl<T> Zeroable for [T;  8] where T: Zeroable {}
-impl<T> Zeroable for [T;  9] where T: Zeroable {}
-impl<T> Zeroable for [T; 10] where T: Zeroable {}
-impl<T> Zeroable for [T; 11] where T: Zeroable {}
-impl<T> Zeroable for [T; 12] where T: Zeroable {}
-impl<T> Zeroable for [T; 13] where T: Zeroable {}
-impl<T> Zeroable for [T; 14] where T: Zeroable {}
-impl<T> Zeroable for [T; 15] where T: Zeroable {}
-impl<T> Zeroable for [T; 16] where T: Zeroable {}
-impl<T> Zeroable for [T; 17] where T: Zeroable {}
-impl<T> Zeroable for [T; 18] where T: Zeroable {}
-impl<T> Zeroable for [T; 19] where T: Zeroable {}
-impl<T> Zeroable for [T; 20] where T: Zeroable {}
-impl<T> Zeroable for [T; 21] where T: Zeroable {}
-impl<T> Zeroable for [T; 22] where T: Zeroable {}
-impl<T> Zeroable for [T; 23] where T: Zeroable {}
-impl<T> Zeroable for [T; 24] where T: Zeroable {}
-impl<T> Zeroable for [T; 25] where T: Zeroable {}
-impl<T> Zeroable for [T; 26] where T: Zeroable {}
-impl<T> Zeroable for [T; 27] where T: Zeroable {}
-impl<T> Zeroable for [T; 28] where T: Zeroable {}
-impl<T> Zeroable for [T; 29] where T: Zeroable {}
-impl<T> Zeroable for [T; 30] where T: Zeroable {}
-impl<T> Zeroable for [T; 31] where T: Zeroable {}
-impl<T> Zeroable for [T; 32] where T: Zeroable {}
-impl<T> Zeroable for [T; 33] where T: Zeroable {}
-impl<T> Zeroable for [T; 34] where T: Zeroable {}
-impl<T> Zeroable for [T; 35] where T: Zeroable {}
-impl<T> Zeroable for [T; 36] where T: Zeroable {}
-impl<T> Zeroable for [T; 37] where T: Zeroable {}
-impl<T> Zeroable for [T; 38] where T: Zeroable {}
-impl<T> Zeroable for [T; 39] where T: Zeroable {}
-impl<T> Zeroable for [T; 40] where T: Zeroable {}
-impl<T> Zeroable for [T; 41] where T: Zeroable {}
-impl<T> Zeroable for [T; 42] where T: Zeroable {}
-impl<T> Zeroable for [T; 43] where T: Zeroable {}
-impl<T> Zeroable for [T; 44] where T: Zeroable {}
-impl<T> Zeroable for [T; 45] where T: Zeroable {}
-impl<T> Zeroable for [T; 46] where T: Zeroable {}
-impl<T> Zeroable for [T; 47] where T: Zeroable {}
-impl<T> Zeroable for [T; 48] where T: Zeroable {}
-impl<T> Zeroable for [T; 49] where T: Zeroable {}
-impl<T> Zeroable for [T; 50] where T: Zeroable {}
-impl<T> Zeroable for [T; 51] where T: Zeroable {}
-impl<T> Zeroable for [T; 52] where T: Zeroable {}
-impl<T> Zeroable for [T; 53] where T: Zeroable {}
-impl<T> Zeroable for [T; 54] where T: Zeroable {}
-impl<T> Zeroable for [T; 55] where T: Zeroable {}
-impl<T> Zeroable for [T; 56] where T: Zeroable {}
-impl<T> Zeroable for [T; 57] where T: Zeroable {}
-impl<T> Zeroable for [T; 58] where T: Zeroable {}
-impl<T> Zeroable for [T; 59] where T: Zeroable {}
-impl<T> Zeroable for [T; 60] where T: Zeroable {}
-impl<T> Zeroable for [T; 61] where T: Zeroable {}
-impl<T> Zeroable for [T; 62] where T: Zeroable {}
-impl<T> Zeroable for [T; 63] where T: Zeroable {}
-impl<T> Zeroable for [T; 64] where T: Zeroable {}
+macro_rules! impls {
+    (array $($tt:tt)*) => { impls!{ [] $(($tt))* } };
+    (tuple $($tt:tt)*) => { impls!{ () void $($tt)* } };
+    (prim $($prim:ident)*) => {$(
+        impl Randomizable for $prim {}
+        impl Zeroable for $prim {}
+    )*};
+
+    ([] $(($n:expr))*) => {$(
+        impl<T: Randomizable> Randomizable for [T; $n] {}
+        impl<T: Zeroable> Zeroable for [T; $n] {}
+    )*};
+
+    (()) => { };
+    (() $head:ident $($tail:ident)*) => {
+        impl<$($tail: Randomizable),*> Randomizable for ($($tail,)*) {}
+        impl<$($tail: Zeroable),*> Zeroable for ($($tail,)*) {}
+        impls!{ () $($tail)* }
+    };
+}
+
+impls!{prim
+    u8 u16 u32 u64
+    i8 i16 i32 i64
+}
+
+impls!{array
+    64 63 62 61 60 59 58 57
+    56 55 54 53 52 51 50 49
+    48 47 46 45 44 43 42 41
+    40 39 38 37 36 35 34 33
+    32 31 30 29 28 27 26 25
+    24 23 22 21 20 19 18 17
+    16 15 14 13 12 11 10  9
+     8  7  6  5  4  3  2  1
+     0
+}
+
+impls!{tuple
+    A B C D E F
+    G H I J K L
+}


### PR DESCRIPTION
One quick question before merging. Is there any reason that the array implementations went up to 64? It is far more common to cover 0..32 (inclusive). The `[T; 0]` was also not included. I've also added the floating point numbers `f32, f64`.

Tuples are simple, this implementation covers `()` (zero size) .. `(A, B, C, D, E, F, G, H, I, J, K, L)` where all implement the relevant marker.

Macro expands to: https://gist.github.com/james-darkfox/c327aab0a5541dfdb5a5

When implementing `PartialEq` on `Sec`, `Eq` is not needed and should only be used when comparing complete equality, which is not asserted on `T`. This isn't really a problem as all secrets are just primitive numbers, which *are* `Eq`. But again, `sodium::cmp` does a bitwise comparison so maybe `Eq` is suitable... This is worth a discussion: "Rust type-level equality" vs "bitwise equality".