### PR TITLE
Establish a BytewiseEq requirement for Secret/SecretVec equality

### DIFF
--- a/src/sec.rs
+++ b/src/sec.rs
@@ -1,7 +1,7 @@
 // This comment prevents Emacs from thinking this file is executable
 #![allow(unsafe_code)]
 
-use marker::{Randomizable, Zeroable};
+use marker::{BytewiseEq, Randomizable, Zeroable};
 
 use sodium;
 
@@ -47,7 +47,7 @@ impl<T> Debug for Sec<T> {
     }
 }
 
-impl<T> PartialEq for Sec<T> {
+impl<T: BytewiseEq> PartialEq for Sec<T> {
     fn eq(&self, s: &Self) -> bool {
         let len = self.len;
         let ret;
@@ -68,7 +68,7 @@ impl<T> PartialEq for Sec<T> {
     }
 }
 
-impl<T> Eq for Sec<T> {}
+impl<T: BytewiseEq> Eq for Sec<T> {}
 
 impl<T> Borrow<T> for Sec<T> {
     fn borrow(&self) -> &T {
@@ -254,8 +254,8 @@ mod tests {
 
     #[test]
     fn it_compares_equality() {
-        let s1 = Sec::<f32>::default(32);
-        let s2 = Sec::<f32>::default(32);
+        let s1 = Sec::<i32>::default(32);
+        let s2 = Sec::<i32>::default(32);
 
         assert_eq!(s1, s2);
         assert_eq!(s2, s1);

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,4 +1,4 @@
-use marker::{Randomizable, Zeroable};
+use marker::{BytewiseEq, Randomizable, Zeroable};
 use sec::Sec;
 
 use std::borrow::{Borrow, BorrowMut};
@@ -89,13 +89,13 @@ pub struct Secret<T> {
     sec: Sec<T>,
 }
 
-impl<T> PartialEq for Secret<T> {
+impl<T: BytewiseEq> PartialEq for Secret<T> {
     fn eq(&self, s: &Self) -> bool {
         self.sec == s.sec
     }
 }
 
-impl<T> Eq for Secret<T> {}
+impl<T: BytewiseEq> Eq for Secret<T> {}
 
 impl<'a, T: Zeroable> From<&'a mut T> for Secret<T> {
     /// Moves the contents of `data` into a `Secret` and zeroes out

--- a/src/secret_vec.rs
+++ b/src/secret_vec.rs
@@ -1,4 +1,4 @@
-use marker::{Randomizable, Zeroable};
+use marker::{BytewiseEq, Randomizable, Zeroable};
 use sec::Sec;
 
 use std::borrow::{Borrow, BorrowMut};
@@ -89,13 +89,13 @@ pub struct SecretVec<T> {
     sec: Sec<T>,
 }
 
-impl<T> PartialEq for SecretVec<T> {
+impl<T: BytewiseEq> PartialEq for SecretVec<T> {
     fn eq(&self, s: &Self) -> bool {
         self.sec == s.sec
     }
 }
 
-impl<T> Eq for SecretVec<T> {}
+impl<T: BytewiseEq> Eq for SecretVec<T> {}
 
 impl<'a, T: Zeroable> From<&'a mut [T]> for SecretVec<T> {
     /// Moves the contents of `data` into a `SecretVec` and zeroes out


### PR DESCRIPTION
/cc @james-darkfox 

We're using `memcmp` to compare bytewise equality of secrets. However, bytewise equality isn't actually a guarantee provided by any of rust's builtin equality traits. I've created a new trait to mark types that have a bytewise equivalence relation, and anything which implements can be compared for equality within a Secret and SecretVec.

Note that Sec, Secret, and SecretVec only implement Eq (and not BytewiseEq), since they themselves cannot be `memcmp`'d to establish equality.

This is technically a backward-incompatible change, as secrets containing floating-point numbers can no longer be compared for equality. This is because `NaN` != `NaN`, and therefore floating-point equality cannot be implied with `memcmp`.