### PR TITLE
This crate now fully builds on Windows.

### DIFF
--- a/src/ffi/sodium.rs
+++ b/src/ffi/sodium.rs
@@ -72,11 +72,15 @@ pub(crate) fn init() -> bool {
 
             // in non-development builds, ensure that core dumps are
             // disabled
+            // On windows no such functionality exists.
+#[cfg(not(windows))]
+{
             if cfg!(any(profile = "release", profile = "coverage")) {
                 failure |= libc::setrlimit(libc::RLIMIT_CORE, &libc::rlimit {
                     rlim_cur: 0,
                     rlim_max: 0,
                 }) == -1;
+}
             }
 
             // sodium_init returns 0 on success, -1 on failure, and 1 if


### PR DESCRIPTION
Made it possible for this create to build on windows. I unfortunately had to add a `#[cfg(...)]` block enclosing the `libc::setrlibit` call because windows has no such functionality that I can find. If there is such functionality, I have absolutely no idea how to do it (one answer to this question suggested that I use "job objects", but I don't know how I'd use those in Rust). I don't know if this lowers the security barrier or not, however.