### PR TITLE
Use `libsodium-sys` with `use-pkg-config` by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,10 @@ readme        = "README.md"
 keywords = [ "crypto", "cryptography", "allocator" ]
 
 [dependencies]
-libc = '0'
-
-[build-dependencies]
-pkg-config = '0.3'
-
-[dev-dependencies]
-libsodium-sys = { version = '0.2', features = ['use-pkg-config'] }
+libc = "0.2"
+libsodium-sys = "0.2.1"
 
 [features]
+default = ["libsodium-use-pkg-config"]
 allow-coredumps = []
+libsodium-use-pkg-config = ["libsodium-sys/use-pkg-config"]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-use pkg_config::{Config as PkgConfig, Library, Error};
-
 use std::env;
 use std::fmt;
 
@@ -52,49 +50,4 @@ impl fmt::Display for Profile {
 
 fn main() {
     let _profile = Profile::infer();
-
-    // 1.0.8 was chosen (IIRC) because this is when the garbage byte
-    // value was fixed at 0xdb
-    if link("libsodium", "1.0.8").is_none() {
-        // if pkg-config is disabled or failed to run, try and link
-        // naïvely
-        println!("cargo:rustc-link-lib=dylib=sodium");
-    };
-}
-
-fn link(name: &str, version: &str) -> Option<Library> {
-    let library = PkgConfig::new()
-        .env_metadata(true)
-        .atleast_version(version)
-        .probe(name);
-
-    match library {
-        Err(Error::Command { command, .. }) => {
-            // The `pkg-config` invocation has extra quotes around it
-            // (most egregiously around the command itself). This is
-            // maybe overly pedantic but cleaning the extra quotes
-            // produces noticeably better printed output.
-            //
-            // The algorithm is a bit dumb. We split on spaces and trim
-            // quotes from both sides if and only if quotes are present
-            // on both sides. This definitely fails in the generic case
-            // (`command "--flag" "\"quoted args\""`) but in the
-            // specific case of pkg-config, it's probably never going to
-            // produce incorrect output in practice.
-            let cmd = command.split(' ').map(|s| {
-                match s.starts_with('"') && s.ends_with('"') {
-                    true  => s.trim_matches('"'),
-                    false => s
-                }
-            }).collect::<Vec<&str>>().join(" ");
-
-            println!("cargo:warning=failed to run `{}`; is pkg-config in your PATH?", cmd);
-            println!("cargo:warning=using default linker options");
-        },
-        Err(Error::EnvNoPkgConfig(_)) => (),
-        Err(err)                      => panic!("failed to link against {}: {}", name, err),
-        Ok(lib)                       => return Some(lib),
-    };
-
-    None
 }

--- a/src/ffi/sodium.rs
+++ b/src/ffi/sodium.rs
@@ -5,7 +5,12 @@
 use std::mem;
 use std::sync::Once;
 
-use libc::{self, c_int, c_void, size_t};
+use libc::{self, size_t};
+use libsodium_sys::{
+    randombytes_buf, sodium_allocarray, sodium_free, sodium_init,
+    sodium_memcmp, sodium_memzero, sodium_mlock, sodium_mprotect_noaccess,
+    sodium_mprotect_readonly, sodium_mprotect_readwrite, sodium_munlock,
+};
 
 /// The global [`sync::Once`] that ensures we only perform
 /// library initialization one time.
@@ -18,25 +23,6 @@ static mut INITIALIZED: bool = false;
 #[cfg(test)]
 thread_local! {
     static FAIL: std::cell::Cell<bool> = std::cell::Cell::new(false);
-}
-
-extern "C" {
-    fn sodium_init() -> c_int;
-
-    fn sodium_allocarray(count: size_t, size: size_t) -> *mut c_void;
-    fn sodium_free(ptr: *mut c_void);
-
-    fn sodium_mlock(ptr: *mut c_void, len: size_t) -> c_int;
-    fn sodium_munlock(ptr: *mut c_void, len: size_t) -> c_int;
-
-    fn sodium_mprotect_noaccess(ptr: *mut c_void) -> c_int;
-    fn sodium_mprotect_readonly(ptr: *mut c_void) -> c_int;
-    fn sodium_mprotect_readwrite(ptr: *mut c_void) -> c_int;
-
-    fn sodium_memcmp(l: *const c_void, r: *const c_void, len: size_t) -> c_int;
-    fn sodium_memzero(ptr: *mut c_void, len: size_t);
-
-    fn randombytes_buf(ptr: *mut c_void, len: size_t);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This removes the old linkage way, but does not change the behavior.

Note: CI fails because of clippy. I will rebase this after you accept #81.