### PR TITLE
Allow linking with libsodium-sys via sodiumoxide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for using `libsodium-sys` as the source of our `libsodium` C
+  bindings. Speficying `--feature use-libsodium-sys` will bypass linking with
+  `pkg-config` and rely on `libsodium-sys` to provide a suitable library to link
+  against.
+
 ### Fixed
 - Intra-rustdoc links corrected.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,15 @@ readme        = "README.md"
 keywords = [ "crypto", "cryptography", "allocator" ]
 
 [dependencies]
-libc = '0'
+libc          = '0'
+libsodium-sys = { version = '0.2', optional = true }
 
 [build-dependencies]
 pkg-config = '0.3'
 
 [dev-dependencies]
-libsodium-sys = { version = '0.2', features = ['use-pkg-config'] }
+libsodium-sys = '0.2'
 
 [features]
-allow-coredumps = []
+allow-coredumps   = []
+use-libsodium-sys = ["libsodium-sys"]

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
-use pkg_config::{Config as PkgConfig, Library, Error};
+#[cfg(not(feature = "use-libsodium-sys"))]
+use pkg_config::{Config as PkgConfig, Error};
 
 use std::env;
 use std::fmt;
@@ -62,7 +63,13 @@ fn main() {
     };
 }
 
-fn link(name: &str, version: &str) -> Option<Library> {
+#[cfg(feature = "use-libsodium-sys")]
+fn link(_name: &str, _version: &str) -> Option<()> {
+    Some(())
+}
+
+#[cfg(not(feature = "use-libsodium-sys"))]
+fn link(name: &str, version: &str) -> Option<()> {
     let library = PkgConfig::new()
         .env_metadata(true)
         .atleast_version(version)
@@ -93,7 +100,7 @@ fn link(name: &str, version: &str) -> Option<Library> {
         },
         Err(Error::EnvNoPkgConfig(_)) => (),
         Err(err)                      => panic!("failed to link against {}: {}", name, err),
-        Ok(lib)                       => return Some(lib),
+        Ok(_)                         => return Some(()),
     };
 
     None

--- a/src/ffi/sodium.rs
+++ b/src/ffi/sodium.rs
@@ -5,7 +5,17 @@
 use std::mem;
 use std::sync::Once;
 
-use libc::{self, c_int, c_void, size_t};
+use libc::{self, size_t};
+
+#[cfg(not(feature = "use-libsodium-sys"))]
+use libc::{c_void, c_int};
+
+#[cfg(feature = "use-libsodium-sys")]
+use libsodium_sys::{
+    randombytes_buf, sodium_allocarray, sodium_free, sodium_init,
+    sodium_memcmp, sodium_memzero, sodium_mlock, sodium_mprotect_noaccess,
+    sodium_mprotect_readonly, sodium_mprotect_readwrite, sodium_munlock,
+};
 
 /// The global [`sync::Once`] that ensures we only perform
 /// library initialization one time.
@@ -20,6 +30,7 @@ thread_local! {
     static FAIL: std::cell::Cell<bool> = std::cell::Cell::new(false);
 }
 
+#[cfg(not(feature = "use-libsodium-sys"))]
 extern "C" {
     fn sodium_init() -> c_int;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,6 @@
 // disabled due to https://github.com/rust-lang/rust/issues/69952
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::wildcard_imports))]
 
-
 /// Macros for ensuring code correctness inspired by [sqlite].
 ///
 /// [sqlite]: https://www.sqlite.org/assert.html


### PR DESCRIPTION
@oblique This isn't quite working yet, secrets isn't seeing the symbols for the libsodium packaged by libsodium-sys:

```
$ cargo test --no-default-features --features use-libsodium-sys
   Compiling libsodium-sys v0.2.5
   Compiling secrets v1.0.0 (/Users/stephen/Development/github.com/stouset/secrets)
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-m64" "-L" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.10d4y3wwrv6otvh3.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.13xxlqh0xw8kpwbm.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.14v2lsbebybs94pa.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.164cs9vpisbx81rh.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.182gbd6qzvjc6pr8.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1dok6wsous8ay0uy.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1dyw8ubt8dz0hhy4.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1exw2nz62qf7lllm.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1f1qyjq78rohmncl.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1g3u00qxmsi2s155.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1gm3hs578laox7id.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1l882uuzhuz9x8dq.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1mnfc3208dwqy3yn.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1o1d84ss8x083yej.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1qbikhsggruhkmi8.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1xtvxtfn5909b3lv.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1ygbgdb5gg41n8gk.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1yq8380h7zcgnzz3.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1z3gf4802o94p2rk.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1zxv2622z1wn7pkh.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.21ip2z6w6e050s0j.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2390f6118uy6jx8.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.24skkb8udfgtnege.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.25d61rhoakyl9733.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.26rsk1zknmskbb8q.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.27cpdrj2oaiw8btt.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.291m5c96ln89m35f.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2a5cwcwlvz2c1uux.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2b1sn5d56qd8zzz3.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2bfzwvadwzeltigf.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2dpzb28tc5w9q5ay.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2dwhinbrfiggjty2.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2eppjsn5o3lx8ha.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2fb0h8dm72aphpjo.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2jrusdwz0il9hu4f.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2kmgy31vmag2m6ci.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2otzxm3vzzakm6zp.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2piyqnmnthsj2mhp.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2ppvbe8o5s72muxq.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2pt7r3qq8mbnlfj1.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2sh4u5a858o4nvc0.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2x3pcq42h891rohz.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2x5pqnii2vkvyopb.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.2xuvsbb6j50mokev.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.34q668pbiv90lqo6.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.36au0xxnwn71kh22.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.37fldbwipnw7n7z2.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.37zbhl1ikeja29a6.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.38wq95zrtys9es2p.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3allgwy3wkfz7djb.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3d3x4grca6j56tij.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3dkib7sw4gox7o7u.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3e0d2e43lyj7m3rv.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3f0i5vcpid3e72p9.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3fpm8oi1sr46uu90.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3fzkt9yrgyx4ygiz.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3henpy0wne7ltld2.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3hnnq4zbjl5g9cul.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3ia7060xqoo5n3wp.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3jjy3e37r8s7kdzq.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3kzrclaiou7pv3bc.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3r89n2ek9jvy5o6i.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3r8mccsq6u73nhx5.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3s993nh6va2gbi7o.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3t0qexucyavoa0x8.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3uax2rm8tsfwtsk2.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3wngs211rdsffnhe.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3wu0qaw10fvjoiox.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3y0rf62kaxkrwma0.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.3y71fvv3r8iwqmvc.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.40a81xheazmjyt7r.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.43t29chdrhym0xpe.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.45j3u5s08a3p7hyw.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.463yroirfkm1i99g.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.46w458afqat2jj0p.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.48p24lnxo7mqqksy.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.49qj4ezq8qlll488.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4b0cpeckgs27wcea.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4d9s35q0t959q8km.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4gdkh61hc84hckor.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4hwnkeqper7fd995.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4jpr2u8w3auan0le.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4k2fz4t9nlpbaybw.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4k8gz9p23v67dozz.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4kyvwqy5wlb3jxvh.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4lc3cbrkay1v9xee.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4qrtzsf4tp18u84d.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4va6fmo151nlctdj.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.4xykeafjq7tj2tmu.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.509nuxwcicwaisoq.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.52ap3a7gkzasrfch.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.52yghvnkdig227xw.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.54ba2czdxrajfw5i.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.55vkvuk7d6mw70yy.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.5a4skjdtnff98t8f.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.5a6tmsttr8wiuitv.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.5bmfzmhekjhlc5kd.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.5bxgrim2exsl3pe3.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.5ztote16oveb17e.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.717pwozb70rsxpe.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.77brmt2mivsi39c.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.77lr2ewabs17fhf.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.8a82f9oohj04bxy.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.97uwrhad3xdfu68.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.9g3bj77dal2moo8.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.9jl8lj56to2dvfp.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.dx4d1c5nax5co1q.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.i67ejiunulh6wqh.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.l2qe60c2qfto6qz.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.mlzx5p5a597ay0l.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.ndd9e4u7d7twmre.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.ni8f2o9j90dkqjl.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.s8ioydu3ot2mqu.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.szlq6eodscfh92c.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.t5xld3xjuj65f33.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.v5ov6590toyedhb.rcgu.o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.xxkxg2jir19dfij.rcgu.o" "-o" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/secrets-661a7d2728c81019.1aun1vmccq3hkxvx.rcgu.o" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps" "-L" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/build/libsodium-sys-03167c89e96d0ed0/out/installed/lib" "-L" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libtest-f3aae3c07b46a1b9.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libterm-6339f3af600fdd34.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libgetopts-a4a55ee648c6f6eb.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libunicode_width-f85a23f819c9e138.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_std-f83c45693b829c57.rlib" "/Users/stephen/Development/github.com/stouset/secrets/target/debug/deps/liblibc-195db325339b57d1.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libstd-473bfa6649025a67.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libpanic_unwind-8e1c1c2f3b88fa26.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libhashbrown-73b777ace327e6f8.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_alloc-b666c9c30cd05ed8.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libbacktrace-13799bdb379be2ce.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libbacktrace_sys-63abd5899e0d7e6b.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/librustc_demangle-1b07ed0286619776.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libunwind-89188c3232051162.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcfg_if-caece456e5f78fce.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/liblibc-628a35dcde52dad2.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/liballoc-a0fac8d46f97ec7a.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_core-ef5998790eeac756.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcore-3fe78a4d2924ae43.rlib" "/Users/stephen/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-e166c2d904273814.rlib" "-lSystem" "-lresolv" "-lc" "-lm"
  = note: Undefined symbols for architecture x86_64:
            "_sodium_mprotect_readwrite", referenced from:
                secrets::ffi::sodium::mprotect_readwrite::h474d775c5b6cfa4d in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readwrite::h60df18b40a4ec1d9 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readwrite::h62e5f6f12be8c6bb in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readwrite::h65a4c6136b70de7e in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readwrite::h70f2d1a6e9892447 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readwrite::h7a1dffd6503597f3 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readwrite::h885d99ccc9d0b1e2 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                ...
            "_sodium_mprotect_noaccess", referenced from:
                secrets::ffi::sodium::mprotect_noaccess::h5ceccb8aa96a34d1 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_noaccess::h6c539286e53ff67d in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_noaccess::h9fbbcee91e2fc4a8 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_noaccess::hae9dc5d1f1ec7fe1 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_noaccess::hb4fa9040b476a9cc in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_noaccess::hc82a680417534464 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_noaccess::hc9ca4068f125c986 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                ...
            "_sodium_mprotect_readonly", referenced from:
                secrets::ffi::sodium::mprotect_readonly::h019eda1a14d4bcd6 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readonly::h2a632d4793a9867f in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readonly::h585a0f19d5ae60f5 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readonly::h5d3cc987dc11fc2d in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readonly::h723c2de217780e14 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readonly::h8488328422b3b4cc in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mprotect_readonly::ha2dbd30ed065fcd3 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                ...
            "_sodium_munlock", referenced from:
                secrets::ffi::sodium::munlock::h21ae55e554282bee in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::munlock::h65e0afe7572bd2fd in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::munlock::h7435df98392d177b in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::munlock::ha28e0647654fefa0 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::munlock::ha349bd92024045ac in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::munlock::haef8804395ab69ae in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
               (maybe you meant: secrets::secret::tests::it_detects_sodium_munlock_failure::_$u7b$$u7b$closure$u7d$$u7d$::he4da3d9052a2baaa, secrets::secret::tests::it_detects_sodium_munlock_failure::hd52534a8494cc257 , secrets::secret::tests::it_detects_sodium_munlock_failure::_$u7b$$u7b$closure$u7d$$u7d$::h465d00648340114d )
            "_sodium_free", referenced from:
                secrets::ffi::sodium::free::h20fddbf6058d5e15 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::free::h38a57b04e81a98e5 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::free::h4b84bb48832f5ac3 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::free::h542b57b878ca15b8 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::free::h777fb3d768ffb302 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::free::h7811ea5513c575c0 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::free::h9ed4e92d4dcf0b08 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                ...
            "_sodium_allocarray", referenced from:
                secrets::ffi::sodium::allocarray::h034cf02e60faf437 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::allocarray::h41815914a65e343f in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::allocarray::h4baaaad44f8add33 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::allocarray::h5d2ea03db841921d in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::allocarray::ha15122cd69ba70b5 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::allocarray::ha342d241a12ab225 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::allocarray::hd31b1bdb9c3d2b04 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                ...
            "_sodium_memcmp", referenced from:
                secrets::ffi::sodium::memcmp::h52115ab97d9ba14f in secrets-661a7d2728c81019.1ygbgdb5gg41n8gk.rcgu.o
            "_sodium_init", referenced from:
                secrets::ffi::sodium::init::_$u7b$$u7b$closure$u7d$$u7d$::h4fedc6fd8de3dcaf in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
               (maybe you meant: secrets::boxed::tests::it_detects_sodium_init_failure::h90ee19433c12555e, secrets::boxed::tests::it_detects_sodium_init_failure::_$u7b$$u7b$closure$u7d$$u7d$::h97a4fdd66299c649 )
            "_sodium_mlock", referenced from:
                secrets::ffi::sodium::mlock::h0eacf33a866befc0 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mlock::h2565b20e3fe9eb0c in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mlock::h3d165a6307fc8c2a in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mlock::h8e501c2b5b837b34 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mlock::hbd45026c7197c3dc in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
                secrets::ffi::sodium::mlock::hc20556c3ea406871 in secrets-661a7d2728c81019.3pf1yjxb9kdai3b3.rcgu.o
               (maybe you meant: secrets::secret::tests::it_detects_sodium_mlock_failure::_$u7b$$u7b$closure$u7d$$u7d$::h45bcd0e9be9679b7, secrets::secret::tests::it_detects_sodium_mlock_failure::h0863e1b9a55630dd , secrets::secret::tests::it_detects_sodium_mlock_failure::_$u7b$$u7b$closure$u7d$$u7d$::h26b8d9228c265b8c )
            "_sodium_memzero", referenced from:
                secrets::ffi::sodium::memzero::hd00977e11cbeaafd in secrets-661a7d2728c81019.1ygbgdb5gg41n8gk.rcgu.o
            "_randombytes_buf", referenced from:
                secrets::ffi::sodium::memrandom::h3a74c0e1e8cbfa20 in secrets-661a7d2728c81019.1ygbgdb5gg41n8gk.rcgu.o
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: aborting due to previous error

error: could not compile `secrets`.

To learn more, run the command again with --verbose.
```