### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,11 @@ keywords = [ "crypto", "cryptography", "allocator" ]
 libc          = '0'
 libsodium-sys = { version = '0.2', optional = true }
 
-[build-dependencies]
+[target.'cfg(target_family = "unix")'.build-dependencies]
 pkg-config = '0.3'
+
+[target.'cfg(target_family = "windows")'.build-dependencies]
+vcpkg = '0.2'
 
 [dev-dependencies]
 libsodium-sys = '0.2'

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "use-libsodium-sys"))]
+#[cfg(all(not(feature = "use-libsodium-sys"), target_family = "unix"))]
 use pkg_config::{Config as PkgConfig, Error};
 
 use std::env;
@@ -68,7 +68,7 @@ fn link(_name: &str, _version: &str) -> Option<()> {
     Some(())
 }
 
-#[cfg(not(feature = "use-libsodium-sys"))]
+#[cfg(all(not(feature = "use-libsodium-sys"), target_family = "unix"))]
 fn link(name: &str, version: &str) -> Option<()> {
     let library = PkgConfig::new()
         .env_metadata(true)
@@ -104,4 +104,15 @@ fn link(name: &str, version: &str) -> Option<()> {
     };
 
     None
+}
+
+#[cfg(all(not(feature = "use-libsodium-sys"), target_family = "windows"))]
+fn link(name: &str, _version: &str) -> Option<()> {
+    match vcpkg::Config::new().emit_includes(true).find_package(name) {
+        Ok(_) => Some( () ),
+        Err(e) => {
+            println!("cargo:warning=failed to find {} in vcpkg: {}", name, e);
+            None
+        }
+    }
 }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -703,7 +703,9 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+// There isn't a great way to run these tests on systems that don't have a native `fork()` call, so
+// we'll just skip them for now.
+#[cfg(all(test, target_family = "unix"))]
 mod tests_sigsegv {
     use super::*;
     use std::process;
@@ -770,7 +772,7 @@ mod tests_sigsegv {
                 val.as_bytes(),
                 val.as_bytes(),
             );
-        })
+        });
     }
 }
 


### PR DESCRIPTION
Building this library on Windows can now be performed automatically if
the library is installed via vcpkg, or if it is manually included.

This work also uncovered a couple things in the library that have been
worked around:
- Some tests do not work well on systems that don't have a native
  `fork()` call. We're skipping those for now.
- There are some quicks about what exactly gets unlocked when
  sodium_munlock is called. These are noted (and worked around for
  windows, due to an error being thrown where it isn't on Linux) but are
  not fixed.