### PR TITLE
Remove unsound `impl Bytes for bool` and `char`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -66,9 +66,6 @@ pub use constant_eq::ConstantEq;
 pub use randomizable::Randomizable;
 pub use zeroable::Zeroable;
 
-unsafe impl Bytes for bool {}
-unsafe impl Bytes for char {}
-
 unsafe impl Bytes for i8    {}
 unsafe impl Bytes for i16   {}
 unsafe impl Bytes for i32   {}


### PR DESCRIPTION
`bool` and `char` are not able to have any arbitrary bit-pattern, so they should not implement `Bytes`.

fixes #100