### PR TITLE
Update libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme        = "README.md"
 keywords = [ "crypto", "cryptography", "allocator" ]
 
 [dependencies]
-libc          = '0'
+libc          = '0.2'
 libsodium-sys = { version = '0.2', optional = true }
 
 [target.'cfg(target_family = "unix")'.build-dependencies]


### PR DESCRIPTION
You don't support libc@0.1. So don't say you do.

Yes, cargo by default will give you libc@0.2, and everything will work. But also, libc could release a version 0.3 with API changes (however unlikely that may be), and you would break because of that. And you don't even have the benefit of allowing a 1.0 libc, either.

You don't necessarily *need* to be fully minimal-versions correct (though it *would* be better if you were), but saying you work with libc@0.1 and libc@0.3 is just completely incorrect.