### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme        = "README.md"
 keywords = [ "crypto", "cryptography", "allocator" ]
 
 [dependencies]
-libc          = '0'
+libc          = '0.2.132'
 libsodium-sys = { version = '0.2', optional = true }
 
 [target.'cfg(target_family = "unix")'.build-dependencies]


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.